### PR TITLE
"Download Flame Graph" option does not work - bug fix

### DIFF
--- a/deploy/https_nginx.conf
+++ b/deploy/https_nginx.conf
@@ -20,6 +20,7 @@ http {
         listen 443 ssl;
         server_name your_domain.com www.your_domain.com; # Replace with your domain
 
+		absolute_redirect off;
         ssl_certificate /etc/nginx/tls/cert.pem; # Path to your SSL certificate
         ssl_certificate_key /etc/nginx/tls/key.pem; # Path to your SSL key
         ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disabled absolute redirect in nginx load balancer, thanks @shirmaor 

## Related Issue

https://github.com/intel/gprofiler-performance-studio/issues/44
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
