### PR TITLE
Add missing workflow permissions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,6 +16,9 @@
 
 name: gProfiler Backend CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,11 +11,15 @@
 #
 name: "CodeQL Advanced"
 
+permissions: 
+  security-events: write
+  
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+  push:
+    tags:
+      - '**'
+      
   schedule:
     - cron: '05 19 * * 2'
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -16,6 +16,9 @@
 
 name: gProfiler Frontend CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Description
Add permission blocks to workflow files, granting workflows only necessary permissions.

## Related Issue
* https://github.com/intel/gprofiler-performance-studio/security/code-scanning/1
* https://github.com/intel/gprofiler-performance-studio/security/code-scanning/2

## Motivation and Context
Increase project security.

## How Has This Been Tested?
* Make sure workflow runs after merge

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ~~I have updated the relevant documentation.~~  N/A
- [x] ~~I have added tests for new logic.~~ N/A
