### PR TITLE
Potential fix for code scanning alert no. 18: Incorrect conversion between integer types

### DIFF
--- a/src/gprofiler_flamedb_rest/common/misc.go
+++ b/src/gprofiler_flamedb_rest/common/misc.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"math"
 	"strings"
 	"time"
 
@@ -52,7 +53,11 @@ func LookupEnvOrDefault[V lookupEnvConstraint](key string, defaultValue V) V {
 			ret = val
 		case int:
 			i, _ := strconv.ParseInt(val, 10, 64)
-			ret = int(i)
+			if i >= math.MinInt && i <= math.MaxInt {
+				ret = int(i)
+			} else {
+				ret = defaultValue
+			}
 		case bool:
 			ret = !(strings.EqualFold(val, "false") || strings.EqualFold(val, "0"))
 		}


### PR DESCRIPTION
I used the autofix feature and what it came up with looks pretty good.  I thought about using MinInt or MaxInt instead of default in the case of under/overflow, but since a default value is passed into the function it probably makes sense to use it instead.

### AI-generated explanation

Potential fix for [https://github.com/intel/gprofiler-performance-studio/security/code-scanning/18](https://github.com/intel/gprofiler-performance-studio/security/code-scanning/18)

To fix the issue, we need to ensure that the conversion from `int64` to `int` is safe and does not result in unexpected values. This can be achieved by adding explicit bounds checks before performing the conversion. The bounds checks should ensure that the parsed value falls within the range of the `int` type.

The best way to fix the problem is:
1. Use the `math` package to determine the maximum and minimum bounds of the `int` type (`math.MaxInt` and `math.MinInt`).
2. Add a conditional check to verify that the parsed value (`i`) falls within these bounds.
3. If the value is out of bounds, return the default value or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
