### PR TITLE
Adjust trigger for codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,10 @@ permissions:
   security-events: write
   
 on:
+  workflow_dispatch:
   pull_request:
   push:
+    branches: [ "master" ]
     tags:
       - '**'
       


### PR DESCRIPTION
## Description
Code scanning appears to be running on the old code after merge instead of the latest code.  Attempt to address this by adding the push master branch condition and allowing manually triggering of the CodeQL workflow.

## How Has This Been Tested?
It will be tested after merge by triggering the manual workflow.
