### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting function

### DIFF
--- a/src/gprofiler/frontend/src/utils/generalUtils.js
+++ b/src/gprofiler/frontend/src/utils/generalUtils.js
@@ -58,6 +58,9 @@ function clone(target) {
     function _clone(b, a) {
         var nextBatch = [];
         for (var key in b) {
+            if (key === "__proto__" || key === "constructor") {
+                continue; // Skip unsafe properties
+            }
             if (typeof b[key] === 'object' && b[key] !== null) {
                 if (b[key] instanceof Array) {
                     a[key] = [];


### PR DESCRIPTION
Potential fix for [https://github.com/intel/gprofiler-performance-studio/security/code-scanning/3](https://github.com/intel/gprofiler-performance-studio/security/code-scanning/3)

To fix the prototype pollution vulnerability in the `clone` function:
1. Block the special property names `__proto__` and `constructor` from being copied from the source object `b` to the target object `a`.
2. Add a conditional check in the loop on line 60 to skip these property names.
3. Ensure that the fix does not alter the existing functionality of the `clone` function.

The changes will be made in the `clone` function, specifically in the `_clone` helper function, to filter out unsafe property names during the recursive copying process.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
