### PR TITLE
Workaround for broken "Download Flame Graph" feature

### DIFF
--- a/src/gprofiler/frontend/src/components/profiles/header/ProfilesActions.jsx
+++ b/src/gprofiler/frontend/src/components/profiles/header/ProfilesActions.jsx
@@ -49,7 +49,6 @@ const DownloadLink = ({ serviceName, timeSelection, activeFilters, fileType, dow
             className='download-svg-link'
             style={{ display: 'none' }}
             ref={downloadRef}
-            target='_blank'
             rel='noopener noreferrer'>
             {''}
         </a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the behavior where a new tab opens when the user clicks "Download Flame Graph".  With this change, the download occurs in the current tab.

## Related Issue
https://github.com/intel/gprofiler-performance-studio/issues/44

## Motivation and Context
This is a workaround for issue #44, where the download does not work.  The root cause of the issue seems to be that the download is happening over http instead of https, causing the browser (Chrome in this case) to block the download entirely when it happens in a different tab.  With this change, the browser "blocks" the download but gives the user the option to keep the file anyway.  

For the long term, we should change the backend so that the download happens in https instead of http.

## How Has This Been Tested?
- [x] Local test server
- [x] Test on original config (will ask the original poster of #44)

## Checklist:
- [x] I have updated the relevant documentation. (N/A)
- [x] I have added tests for new logic.  (N/A)
