### PR TITLE
fix clickhouse schema

### DIFF
--- a/src/gprofiler_indexer/sql/create_ch_schema_cluster_mode.sql
+++ b/src/gprofiler_indexer/sql/create_ch_schema_cluster_mode.sql
@@ -114,6 +114,8 @@ CREATE TABLE IF NOT EXISTS flamedb.samples_1hour_local_store ON CLUSTER '{cluste
     ContainerEnvName  LowCardinality(String),
     HostName          LowCardinality(String),
     ContainerName     LowCardinality(String),
+    HostNameHash      UInt32,
+    ContainerNameHash UInt32,
     CallStackHash     UInt64,
     CallStackName     String CODEC (ZSTD),
     CallStackParent   UInt64,
@@ -122,7 +124,7 @@ CREATE TABLE IF NOT EXISTS flamedb.samples_1hour_local_store ON CLUSTER '{cluste
     ErrNumSamples      UInt32
     ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}', (NumSamples))
     PARTITION BY toYYYYMMDD(Timestamp)
-    ORDER BY (ServiceId, ContainerEnvName, InstanceType, Timestamp, CallStackHash, CallStackParent);
+    ORDER BY (ServiceId, ContainerEnvName, InstanceType, HostNameHash, ContainerNameHash, Timestamp, CallStackHash, CallStackParent);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS flamedb.samples_1hour_local ON CLUSTER '{cluster}' TO
     flamedb.samples_1hour_local_store AS
@@ -159,6 +161,8 @@ CREATE TABLE IF NOT EXISTS flamedb.samples_1day_local_store ON CLUSTER '{cluster
     ContainerEnvName  LowCardinality(String),
     HostName          LowCardinality(String),
     ContainerName     LowCardinality(String),
+    HostNameHash      UInt32,
+    ContainerNameHash UInt32,
     CallStackHash     UInt64,
     CallStackName     String CODEC (ZSTD),
     CallStackParent   UInt64,
@@ -167,7 +171,7 @@ CREATE TABLE IF NOT EXISTS flamedb.samples_1day_local_store ON CLUSTER '{cluster
     ErrNumSamples      UInt32
     ) ENGINE = ReplicatedSummingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}', (NumSamples))
     PARTITION BY toYYYYMMDD(Timestamp)
-    ORDER BY (ServiceId, ContainerEnvName, InstanceType, Timestamp, CallStackHash, CallStackParent);
+    ORDER BY (ServiceId, ContainerEnvName, InstanceType, HostNameHash, ContainerNameHash, Timestamp, CallStackHash, CallStackParent);
 
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS flamedb.samples_1day_local ON CLUSTER '{cluster}' TO


### PR DESCRIPTION

## Description
Current clickhouse cannot be applied in cluster mode due to couple of columns not present in local store but present in materialized view 



## Motivation and Context
Ability to spin clickhouse cluster with sample DB

## How Has This Been Tested?
apply ddl clickhouse-client --multiquery < /var/log/ch_config/create_ch_schema_cluster_mode.sql and make sure it executes successfully on all nodes in clickhouse cluster

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
