### PR TITLE
Fix HTTP listener BasicAuth bypass in Nginx config

### DIFF
--- a/deploy/https_nginx.conf
+++ b/deploy/https_nginx.conf
@@ -25,7 +25,7 @@ http {
         }
 
         location / {
-            proxy_pass http://webapp;
+            return 301 https://$host$request_uri;
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix authentication bypass vulnerability where HTTP listener (port 8080) proxied requests directly to backend without BasicAuth
- HTTP catch-all location now redirects to HTTPS where BasicAuth is enforced
- Restores secure behavior that existed before commit cb85c25

## Details

The HTTP server block in `deploy/https_nginx.conf` was intended for redirecting to HTTPS (per the comment), but was actually proxying all traffic directly to the webapp without authentication. This allowed unauthenticated access to sensitive endpoints like `/api/api_key` via HTTP port 8080, while the same endpoints required BasicAuth on HTTPS port 4433.

## Test plan

- [ ] Verify `GET http://localhost:8080/api/api_key` returns `301` redirect to HTTPS
- [ ] Verify `GET https://localhost:4433/api/api_key` without auth returns `401`
- [ ] Verify `GET https://localhost:4433/api/api_key` with valid BasicAuth returns `200`
- [ ] Verify agent endpoints (`/api/v2/profiles`, `/api/v1/logs`, etc.) still work over HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)